### PR TITLE
Fixed warning in UISSUserInterfaceIdiomPreprocessor.m

### DIFF
--- a/Project/UISS/UISSUserInterfaceIdiomPreprocessor.m
+++ b/Project/UISS/UISSUserInterfaceIdiomPreprocessor.m
@@ -20,7 +20,7 @@
     NSMutableDictionary *preprocessed = [NSMutableDictionary dictionary];
     
     [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id object, BOOL *stop) {
-        UIUserInterfaceIdiom idiom = (UIUserInterfaceIdiom) [self userInterfaceIdiomFromKey:key];
+        NSInteger idiom = [self userInterfaceIdiomFromKey:key];
         
         if (idiom == NSNotFound) {
             [preprocessed setObject:[self preprocessValueIfNecessary:object userInterfaceIdiom:userInterfaceIdiom] forKey:key];


### PR DESCRIPTION
Xcode 5 reports the following warning:

```
UISSUserInterfaceIdiomPreprocessor.m:25:19: Comparison of constant 'NSNotFound' (2147483647) with expression of type 'UIUserInterfaceIdiom' (aka 'enum UIUserInterfaceIdiom') is always false
```

Fixed by no longer casting `NSInteger` (possibly holding a non-`UIUserInterfaceIdiom` value) to `UIUserInterfaceIdiom`.
