### PR TITLE
#56 issue fix about app extensions availability

### DIFF
--- a/Project/UISS/UISS.m
+++ b/Project/UISS/UISS.m
@@ -176,14 +176,15 @@ NSString *const UISSDidRefreshViewsNotification = @"UISSDidRefreshViewsNotificat
 
 - (void)refreshViews {
     [[NSNotificationCenter defaultCenter] postNotificationName:UISSWillRefreshViewsNotification object:self];
-
+#if !defined(UISS_APP_EXTENSIONS)
+    //This code is not available for app extensions (see today extension)
     for (UIWindow *window in [UIApplication sharedApplication].windows) {
         for (UIView *view in window.subviews) {
             [view removeFromSuperview];
             [window addSubview:view];
         }
     }
-
+#endif
     [[NSNotificationCenter defaultCenter] postNotificationName:UISSDidRefreshViewsNotification object:self];
 }
 
@@ -286,6 +287,8 @@ NSString *const UISSDidRefreshViewsNotification = @"UISSDidRefreshViewsNotificat
 }
 
 - (void)presentConsoleViewController {
+#if !defined(UISS_APP_EXTENSIONS)
+    //This code is not available for app extensions (see today extension)
     UISSConsoleViewController *consoleViewController = [[UISSConsoleViewController alloc] initWithUISS:self];
     consoleViewController.modalPresentationStyle = UIModalPresentationFormSheet;
 
@@ -302,6 +305,7 @@ NSString *const UISSDidRefreshViewsNotification = @"UISSDidRefreshViewsNotificat
     } else {
         [presentingViewController presentViewController:consoleViewController animated:YES completion:nil];
     }
+#endif
 }
 
 @end

--- a/Project/UISS/UISSSettingsViewController.m
+++ b/Project/UISS/UISSSettingsViewController.m
@@ -147,6 +147,8 @@
     UISSSettingDescriptor *settingDescriptor = self.settingDescriptors[(NSUInteger) indexPath.section];
 
     if (settingDescriptor.editorType == UISSSettingDescriptorEditorTypeText) {
+#if !defined(UISS_APP_EXTENSIONS)
+        //This code is not available for app extensions (see today extension)
         UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Change Setting"
                                                             message:settingDescriptor.title
                                                            delegate:self
@@ -160,6 +162,7 @@
         textField.keyboardType = settingDescriptor.keyboardType;
 
         [alertView show];
+#endif
     }
 }
 

--- a/Project/UISS/UISSStatusWindow.m
+++ b/Project/UISS/UISSStatusWindow.m
@@ -17,7 +17,12 @@
 
 - (id)init
 {
+#if !defined(UISS_APP_EXTENSIONS)
+    //This code is not available for app extensions (see today extension)
     self = [super initWithFrame:[UIApplication sharedApplication].statusBarFrame];
+#else
+    self = [super initWithFrame:CGRectZero];
+#endif
     self.clipsToBounds = YES;
     self.backgroundColor = [UIColor clearColor];
     if (self) {
@@ -37,9 +42,14 @@
     });
 }
 
-- (void)updateLayout;
+- (void)updateLayout
 {
+#if !defined(UISS_APP_EXTENSIONS)
+    //This code is not available for app extensions (see today extension)
     self.frame = [self frameForOrientation:[UIApplication sharedApplication].statusBarOrientation];
+#else
+    self.frame = [self frameForOrientation:UIInterfaceOrientationUnknown];
+#endif
     self.rootViewController.view.frame = self.bounds;
 }
 

--- a/UISS.podspec
+++ b/UISS.podspec
@@ -12,11 +12,21 @@ Pod::Spec.new do |s|
 
   s.source   = { :git => 'https://github.com/robertwijas/UISS.git', :tag => "#{s.version}" }
 
-  s.source_files = 'Project/UISS'
   s.resources = 'Project/UISSResources.bundle'
   s.prefix_header_file = 'Project/UISS/UISS-Prefix.pch'
 
   s.frameworks = 'Foundation', 'UIKit'
 
-  s.requires_arc = true
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |core|
+    core.source_files = 'Project/UISS'
+    core.requires_arc = true
+  end
+
+  s.subspec 'Extensions' do |ext|
+    ext.dependency 'UISS/Core'
+    ext.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'UISS_APP_EXTENSIONS' }
+  end
+
 end


### PR DESCRIPTION
- New preprocessor macro added. Check if it is defined, in order to run the blocks of code which are unavailable in app extensions (see sharedApplication)
- Podspec file modified. New subspec about app extensions added, in which the preprocessor macro is defined